### PR TITLE
Fix incorrect field name

### DIFF
--- a/Console/Command/RestoreUseDefaultValueCommand.php
+++ b/Console/Command/RestoreUseDefaultValueCommand.php
@@ -62,8 +62,8 @@ class RestoreUseDefaultValueCommand extends Command
                 // Select the global value if it's the same as the non-global value
                 $results = $db->fetchAll(
                     'SELECT * FROM ' . $fullTableName
-                    . ' WHERE attribute_id = ? AND store_id = ? AND entity_id = ? AND value = ?',
-                    array($row['attribute_id'], 0, $row['entity_id'], $row['value'])
+                    . ' WHERE attribute_id = ? AND store_id = ? AND row_id = ? AND value = ?',
+                    array($row['attribute_id'], 0, $row['row_id'], $row['value'])
                 );
 
                 if (count($results) > 0) {


### PR DESCRIPTION
Catalog_product_entity tables use row_id not entity_id for their associations as of at least 2.3.5, suggesting this fix, but lmk if there is a good way to test or gate this to the proper version if that is due to a schema change along the line.

Fixes error:
```In ErrorHandler.php line 61:
  Notice: Undefined index: entity_id in ./vendor/hackathon/magento2-eavcleaner/Console/Command/RestoreUseDefaultValueCommand.php on line 66
```